### PR TITLE
Option to hide clock with GUI

### DIFF
--- a/Common/src/main/java/com/natamus/guiclock/config/ConfigHandler.java
+++ b/Common/src/main/java/com/natamus/guiclock/config/ConfigHandler.java
@@ -15,6 +15,7 @@ public class ConfigHandler extends DuskConfig {
 	@Entry public static boolean lowerClockWhenPlayerHasEffects = true;
 	@Entry public static boolean _24hourformat = true;
 	@Entry public static boolean showOnlyMinecraftClockIcon = false;
+	@Entry public static boolean hideWithGUI = true;
 	@Entry public static boolean showBothTimes = false;
 	@Entry public static boolean showRealTime = false;
 	@Entry public static boolean showRealTimeSeconds = false;

--- a/Common/src/main/java/com/natamus/guiclock/events/GUIEvent.java
+++ b/Common/src/main/java/com/natamus/guiclock/events/GUIEvent.java
@@ -23,7 +23,9 @@ public class GUIEvent {
 	private static String daystring = "";
 	
 	public static void renderOverlay(GuiGraphics guiGraphics, DeltaTracker deltaTracker) {
-		if (mc.gui.getDebugOverlay().showDebugScreen()) {
+		boolean hideGUI = ConfigHandler.hideWithGUI;
+
+		if (mc.gui.getDebugOverlay().showDebugScreen() || mc.level == null || (mc.options.hideGui && hideGUI)) {
 			return;
 		}
 


### PR DESCRIPTION
Added option to hide clock with GUI. It's annoying when screenshot have this clock, but don't need it.
### Before:
![2024-11-09_12 37 32](https://github.com/user-attachments/assets/06c4100f-6694-43f5-9e34-b37d56404ecc)
### After:
![2024-11-09_12 37 41](https://github.com/user-attachments/assets/e20fb760-48a2-4e7c-a048-5c7c604e17af)
