### PR TITLE
Fix game time overflow due to long casting to int

### DIFF
--- a/Common/src/main/java/com/natamus/guiclock/events/GUIEvent.java
+++ b/Common/src/main/java/com/natamus/guiclock/events/GUIEvent.java
@@ -186,9 +186,9 @@ public class GUIEvent {
 	}
 	
 	private static String getGameTime() {
-		int time;
-		int gametime = (int)mc.level.getDayTime();
-		int daysplayed = 0;
+		long time;
+		long gametime = mc.level.getDayTime();
+		long daysplayed = 0;
 		
 		while (gametime >= 24000) {
 			gametime-=24000;


### PR DESCRIPTION
This PR fixes an issue where `gametime` overflows and stops behaving correctly when the gametime exceeds the Java integer limit. Although you may only set the gametime to a value within the integer limit, the game can naturally tick over this limit (1242 real-life days), or setting it using tools like NBT Explorer. 