### PR TITLE
Use Correct HUD render event on 1.20.1

### DIFF
--- a/Forge/src/main/java/com/natamus/guiclock/forge/events/ForgeGUIEvent.java
+++ b/Forge/src/main/java/com/natamus/guiclock/forge/events/ForgeGUIEvent.java
@@ -4,7 +4,7 @@ import com.natamus.guiclock.events.GUIEvent;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.entity.ItemRenderer;
-import net.minecraftforge.client.event.RenderGuiOverlayEvent;
+import net.minecraftforge.client.event.RenderGuiEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 
@@ -14,7 +14,7 @@ public class ForgeGUIEvent extends Gui {
 	}
 	
 	@SubscribeEvent(priority = EventPriority.NORMAL)
-	public void renderOverlay(RenderGuiOverlayEvent.Post e) {
+	public void renderOverlay(RenderGuiEvent.Post e) {
 		GUIEvent.renderOverlay(e.getGuiGraphics(), e.getPartialTick());
 	}
 }


### PR DESCRIPTION
Currently the 1.20.1 version of the mod listens to `RenderGuiOverlayEvent.Post` to render the HUD. Unfortunately, as indicated by the "Overlay" part in the name, this event is posted every time an "overlay" is rendered (e.x. health bar, experience bar, hotbar, ...) Plus, mods are able to register their own overlays. This means in a large enough modpack, this mod's HUD may end up rendering 50+ times a frame! which bricks performance.

The simple fix is to use `RenderGuiEvent.Post`.

This fix should be straightforward enough but it's not tested. Please provide build instructions as ~`gradlew build` does not produce a usable mod jar.~ (according to https://github.com/Serilum/.issue-tracker/issues/2508#issuecomment-2241040720 , either build Collective locally or use the jar on the maven.)